### PR TITLE
Master Gemfiles in each folder?

### DIFF
--- a/appdev/Dockerfile
+++ b/appdev/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal
+FROM --platform=linux/x86_64 buildpack-deps:focal
 
 ### base ###
 RUN yes | unminimize \

--- a/appdev/Dockerfile
+++ b/appdev/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 buildpack-deps:focal
+FROM buildpack-deps:focal
 
 ### base ###
 RUN yes | unminimize \

--- a/appdev/Gemfile
+++ b/appdev/Gemfile
@@ -1,0 +1,73 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '2.7.3'
+
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'rails', '~> 6.0.3', '>= 6.0.3.2'
+# Use sqlite3 as the database for Active Record
+
+# Use Puma as the app server
+gem 'puma', '~> 4.1'
+
+# Use Active Model has_secure_password
+gem 'bcrypt'
+
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', '>= 1.4.2', require: false
+
+group :development, :test do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+end
+
+group :development do
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  gem 'web-console', '>= 3.3.0'
+  gem 'listen', '~> 3.2'
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'rack-timeout', require: 'rack/timeout/base'
+gem 'sprockets', '< 4'
+gem 'sassc-rails'
+gem 'execjs'
+gem 'therubyracer', platforms: :ruby
+
+group :development, :test do
+  gem 'amazing_print'
+  gem 'dotenv-rails'
+  gem 'grade_runner', github: 'firstdraft/grade_runner'
+  gem 'pry-rails'
+  gem 'sqlite3', '~> 1.4.1'
+  gem 'table_print'
+  gem 'web_git', github: 'firstdraft/web_git'
+end
+
+group :development do
+  gem 'annotate'
+  gem 'better_errors', '2.6'
+  gem 'binding_of_caller'
+  gem 'draft_generators', github: 'firstdraft/draft_generators'
+  gem 'rails_db', '2.3.1'
+  gem 'rufo'
+  gem 'htmlbeautifier'
+end
+
+group :test do
+  gem 'capybara'
+  gem 'factory_bot_rails'
+  gem 'rspec-rails'
+  gem 'webmock'
+  gem 'rspec-html-matchers'
+  gem 'selenium-webdriver'
+end
+
+group :production do
+  gem 'pg'
+end

--- a/appdev/Gemfile.lock
+++ b/appdev/Gemfile.lock
@@ -1,0 +1,416 @@
+GIT
+  remote: https://github.com/firstdraft/draft_generators.git
+  revision: 4b0d9b35d61c6582beb78504f5e0291953189924
+  specs:
+    draft_generators (0.0.3)
+      devise
+
+GIT
+  remote: https://github.com/firstdraft/grade_runner.git
+  revision: 93e5954a4c7e0e23395644039d4bd26e2411a3c6
+  specs:
+    grade_runner (0.0.3.pre.3)
+      oj
+
+GIT
+  remote: https://github.com/firstdraft/web_git.git
+  revision: 614ba241422a5516f5a0a02ff75557640e87a855
+  specs:
+    web_git (0.1.0)
+      actionview
+      ansispan
+      diffy
+      git
+      sinatra
+      tzinfo-data
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      activestorage (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+      mail (>= 2.7.1)
+    actionmailer (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      actionview (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (6.0.4.8)
+      actionview (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+      rack (~> 2.0, >= 2.0.8)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      activestorage (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+      nokogiri (>= 1.8.5)
+    actionview (6.0.4.8)
+      activesupport (= 6.0.4.8)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (6.0.4.8)
+      activesupport (= 6.0.4.8)
+      globalid (>= 0.3.6)
+    activemodel (6.0.4.8)
+      activesupport (= 6.0.4.8)
+    activerecord (6.0.4.8)
+      activemodel (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+    activestorage (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      marcel (~> 1.0.0)
+    activesupport (6.0.4.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.4.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
+    ansispan (0.0.1)
+    bcrypt (3.1.17)
+    bcrypt (3.1.17-java)
+    better_errors (2.6.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    bindex (0.8.1)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
+    bootsnap (1.11.1)
+      msgpack (~> 1.2)
+    builder (3.2.4)
+    byebug (11.1.3)
+    capybara (3.36.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (4.1.0)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
+    crass (1.0.6)
+    debug_inspector (1.1.0)
+    devise (4.8.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    diff-lcs (1.5.0)
+    diffy (3.4.2)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
+    erubi (1.10.0)
+    execjs (2.8.1)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    ffi (1.15.5)
+    ffi (1.15.5-java)
+    ffi (1.15.5-x64-mingw32)
+    ffi (1.15.5-x86-mingw32)
+    git (1.11.0)
+      rchardet (~> 1.8)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    hashdiff (1.0.1)
+    htmlbeautifier (1.4.2)
+    i18n (1.11.0)
+      concurrent-ruby (~> 1.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
+    libv8 (3.16.14.19)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    loofah (2.18.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    marcel (1.0.2)
+    matrix (0.4.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
+    minitest (5.16.2)
+    msgpack (1.5.1)
+    msgpack (1.5.1-java)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.8)
+    nio4r (2.5.8-java)
+    nokogiri (1.13.7)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.7-java)
+      racc (~> 1.4)
+    nokogiri (1.13.7-x64-mingw32)
+      racc (~> 1.4)
+    nokogiri (1.13.7-x86-mingw32)
+      racc (~> 1.4)
+    oj (3.13.11)
+    orm_adapter (0.5.0)
+    pg (1.3.5)
+    pg (1.3.5-x64-mingw32)
+    pg (1.3.5-x86-mingw32)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
+    public_suffix (4.0.7)
+    puma (4.3.12)
+      nio4r (~> 2.0)
+    puma (4.3.12-java)
+      nio4r (~> 2.0)
+    racc (1.6.0)
+    racc (1.6.0-java)
+    rack (2.2.4)
+    rack-protection (2.2.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rack-timeout (0.6.0)
+    rails (6.0.4.8)
+      actioncable (= 6.0.4.8)
+      actionmailbox (= 6.0.4.8)
+      actionmailer (= 6.0.4.8)
+      actionpack (= 6.0.4.8)
+      actiontext (= 6.0.4.8)
+      actionview (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      activemodel (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      activestorage (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+      bundler (>= 1.3.0)
+      railties (= 6.0.4.8)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.3)
+      loofah (~> 2.3)
+    rails_db (2.3.1)
+      activerecord
+      kaminari
+      rails (>= 5.0.0)
+      ransack (>= 2.3.2)
+      simple_form (>= 5.0.1)
+      terminal-table
+    railties (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.20.3, < 2.0)
+    rake (13.0.6)
+    ransack (3.1.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
+    rb-fsevent (0.11.1)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rchardet (1.8.0)
+    ref (2.0.0)
+    regexp_parser (2.3.1)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-html-matchers (0.9.4)
+      nokogiri (~> 1)
+      rspec (>= 3.0.0.a, < 4)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-rails (5.1.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      rspec-mocks (~> 3.10)
+      rspec-support (~> 3.10)
+    rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
+    rufo (0.13.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc (2.4.0-x64-mingw32)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
+    selenium-webdriver (4.1.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2)
+    simple_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
+    sinatra (2.2.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
+      tilt (~> 2.0)
+    spoon (0.0.6)
+      ffi
+    spring (2.1.1)
+    spring-watcher-listen (2.0.1)
+      listen (>= 2.7, < 4.0)
+      spring (>= 1.2, < 3.0)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.4.2)
+    table_print (1.5.7)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
+    thor (1.2.1)
+    thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
+    tilt (2.0.10)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2022.1)
+      tzinfo (>= 1.0.0)
+    unicode-display_width (2.1.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
+    web-console (4.2.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-driver (0.7.5-java)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+    zeitwerk (2.6.0)
+
+PLATFORMS
+  java
+  ruby
+  x64-mingw32
+  x86-mingw32
+  x86-mswin32
+
+DEPENDENCIES
+  amazing_print
+  annotate
+  bcrypt
+  better_errors (= 2.6)
+  binding_of_caller
+  bootsnap (>= 1.4.2)
+  byebug
+  capybara
+  dotenv-rails
+  draft_generators!
+  execjs
+  factory_bot_rails
+  grade_runner!
+  htmlbeautifier
+  listen (~> 3.2)
+  pg
+  pry-rails
+  puma (~> 4.1)
+  rack-timeout
+  rails (~> 6.0.3, >= 6.0.3.2)
+  rails_db (= 2.3.1)
+  rspec-html-matchers
+  rspec-rails
+  rufo
+  sassc-rails
+  selenium-webdriver
+  spring
+  spring-watcher-listen (~> 2.0.0)
+  sprockets (< 4)
+  sqlite3 (~> 1.4.1)
+  table_print
+  therubyracer
+  tzinfo-data
+  web-console (>= 3.3.0)
+  web_git!
+  webmock
+
+RUBY VERSION
+   ruby 2.7.3p183
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
I'm trying to build images from these Dockerfiles, and I got the error about a missing `Gemfile` and `Gemfile.lock`. Does it make sense to include a master `Gemfile`s in both the "appdev" and "appdev2" directories, so this repository can be the one-stop-shop for building an image for the Phase I and Phase II projects?

My temporary solution on this PR was to copy the `Gemfile`s from Photogram Signin, which is the last class project from AD1, and theoretically has all the required gems. Not sure what the master Gemfile would be for AD2.